### PR TITLE
MODLD-845: Update the fingerprint rules for ID_UNKNOWN and ID_IAN

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 - Update fingerprinting rule for ISSN to include Status [MODLD-798](https://folio-org.atlassian.net/browse/MODLD-798)
 - Replace ID_EAN with ID_IAN. Remove property EAN_VALUE. [MODLD-810](https://folio-org.atlassian.net/browse/MODLD-810)
 - PUBLICATION_FREQUENCY property removed [MODLD-817](https://folio-org.atlassian.net/browse/MODLD-817)
+- Update the fingerprint rules for ID_UNKNOWN and ID_IAN [MODLD-845](https://folio-org.atlassian.net/browse/MODLD-845)
 
 ## 1.0.1 (03-12-2025)
 - Initial release

--- a/src/main/resources/fingerprint-rules.yml
+++ b/src/main/resources/fingerprint-rules.yml
@@ -78,10 +78,16 @@ rules:
     properties:
       - NAME
       - QUALIFIER
+    edges:
+      - predicate: STATUS
+        label: true
   - types: ID_UNKNOWN, IDENTIFIER
     properties:
       - NAME
       - QUALIFIER
+    edges:
+      - predicate: STATUS
+        label: true
   - types: STATUS
     properties:
       - LABEL

--- a/src/test/java/org/folio/ld/fingerprint/FingerprintServiceIT.java
+++ b/src/test/java/org/folio/ld/fingerprint/FingerprintServiceIT.java
@@ -10,8 +10,10 @@ import static org.folio.ld.fingerprint.test.TestUtil.categorySet;
 import static org.folio.ld.fingerprint.test.TestUtil.ddcClassification;
 import static org.folio.ld.fingerprint.test.TestUtil.dissertation;
 import static org.folio.ld.fingerprint.test.TestUtil.extent;
+import static org.folio.ld.fingerprint.test.TestUtil.id_ian;
 import static org.folio.ld.fingerprint.test.TestUtil.id_isbn;
 import static org.folio.ld.fingerprint.test.TestUtil.id_lccn;
+import static org.folio.ld.fingerprint.test.TestUtil.id_unknown;
 import static org.folio.ld.fingerprint.test.TestUtil.instance;
 import static org.folio.ld.fingerprint.test.TestUtil.instanceTitle;
 import static org.folio.ld.fingerprint.test.TestUtil.languageCategory;
@@ -51,8 +53,10 @@ class FingerprintServiceIT {
       Arguments.of(categorySet(), "categorySet.json"),
       Arguments.of(dissertation(), "dissertation.json"),
       Arguments.of(meetingConcept(), "meetingConcept.json"),
+      Arguments.of(id_ian(), "id_ian.json"),
       Arguments.of(id_lccn(), "id_lccn.json"),
       Arguments.of(id_isbn(), "id_isbn.json"),
+      Arguments.of(id_unknown(), "id_unknown.json"),
       Arguments.of(instance(), "instance.json"),
       Arguments.of(instanceTitle(), "instanceTitle.json"),
       Arguments.of(parallelTitle(), "parallelTitle.json"),

--- a/src/test/java/org/folio/ld/fingerprint/test/TestUtil.java
+++ b/src/test/java/org/folio/ld/fingerprint/test/TestUtil.java
@@ -810,6 +810,25 @@ public class TestUtil {
     ).setLabel("lccn value");
   }
 
+  public static Resource id_ian() {
+    return getResource(
+      Map.of(
+        NAME, List.of("ian value"),
+        QUALIFIER, List.of("ian qualifier")
+      ),
+      Set.of(IDENTIFIER, ID_IAN),
+      Map.of(STATUS, List.of(status("ian")))
+    ).setLabel("ian value");
+  }
+
+  public static Resource id_unknown() {
+    return getResource(
+      Map.of(NAME, List.of("unknown id value")),
+      Set.of(IDENTIFIER, ID_UNKNOWN),
+      Map.of(STATUS, List.of(status("unknown")))
+    ).setLabel("unknown id value");
+  }
+
   public static Resource id_isbn() {
     return getResource(
       Map.of(NAME, List.of("isbn value")),

--- a/src/test/resources/fingerprints_expected/id_ian.json
+++ b/src/test/resources/fingerprints_expected/id_ian.json
@@ -1,0 +1,1 @@
+[["http://bibfra.me/purl/versa/type","http://bibfra.me/vocab/lite/Identifier"],["http://bibfra.me/purl/versa/type","http://library.link/identifier/IAN"],["http://bibfra.me/vocab/lite/label","ian status value"],["http://bibfra.me/vocab/lite/name","ian value"],["http://bibfra.me/vocab/marc/qualifier","ian qualifier"]]

--- a/src/test/resources/fingerprints_expected/id_unknown.json
+++ b/src/test/resources/fingerprints_expected/id_unknown.json
@@ -1,0 +1,1 @@
+[["http://bibfra.me/purl/versa/type","http://bibfra.me/vocab/lite/Identifier"],["http://bibfra.me/purl/versa/type","http://library.link/identifier/UNKNOWN"],["http://bibfra.me/vocab/lite/label","unknown status value"],["http://bibfra.me/vocab/lite/name","unknown id value"]]


### PR DESCRIPTION
Update the fingerprint rules for ID_UNKNOWN and ID_IAN to consider the "STATUS" value.